### PR TITLE
Map: do not draw label if tile image rendered successfully

### DIFF
--- a/lib/Platinenmacher/gui/map.c
+++ b/lib/Platinenmacher/gui/map.c
@@ -163,7 +163,7 @@ void map_attach_onAfterRender_callback(map_t* map, error_code_t (*cb)(const disp
 error_code_t map_tile_render(const display_t* dsp, void* component)
 {
     map_tile_t* tile = (map_tile_t*)component;
-    if (tile->image && image_render(dsp, tile->image) == PM_OK) {
+    if (tile->image && image_render(dsp, tile->image) != PM_OK) {
         if(tile->label)
             label_render(dsp, tile->label);
         return PM_OK;


### PR DESCRIPTION
This will not render the label text if the map image was rendered.